### PR TITLE
Add export and deletion to inventory CLI

### DIFF
--- a/inventory_cli.py
+++ b/inventory_cli.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import argparse
 import getpass
+from datetime import datetime
 
+import pandas as pd
+from docx import Document
+from fpdf import FPDF
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -26,17 +30,110 @@ def list_assets(session: Session) -> None:
         print("No assets found")
         return
     for a in assets:
-        print(f"{a.id}: {a.name} (code {a.asset_code}) qty={a.quantity}")
+        print(
+            f"{a.id}: code {a.asset_code}, sub {a.sub_code}, year {a.budget_year},"
+            f" name {a.name}, details {a.details}, SN {a.serial_number},"
+            f" category {a.category}, qty {a.quantity}, acquired {a.acquisition_date},"
+            f" unit {a.unit}, price {a.price}, note {a.note}"
+        )
 
 
 def add_asset(session: Session) -> None:
     asset_code = input("Asset code: ")
+    sub_code = input("Sub code: ")
+    budget_year = input("Budget year: ")
     name = input("Name: ")
+    details = input("Details: ")
+    serial_number = input("Serial number: ")
+    category = input("Category: ")
     quantity = int(input("Quantity: ") or 1)
-    asset = Asset(asset_code=asset_code, name=name, quantity=quantity)
+    acq_str = input("Acquisition date (YYYY-MM-DD): ")
+    acquisition_date = (
+        datetime.strptime(acq_str, "%Y-%m-%d").date() if acq_str else None
+    )
+    unit = input("Unit: ")
+    price_str = input("Price: ")
+    price = float(price_str) if price_str else None
+    note = input("Note: ")
+    asset = Asset(
+        asset_code=asset_code,
+        sub_code=sub_code or None,
+        budget_year=budget_year or None,
+        name=name,
+        details=details or None,
+        serial_number=serial_number or None,
+        category=category or None,
+        quantity=quantity,
+        acquisition_date=acquisition_date,
+        unit=unit or None,
+        price=price,
+        note=note or None,
+    )
     session.add(asset)
     session.commit()
     print("Asset added")
+
+
+def delete_asset(session: Session) -> None:
+    asset_id = input("Asset ID to delete: ")
+    asset = session.get(Asset, int(asset_id)) if asset_id else None
+    if not asset:
+        print("Asset not found")
+        return
+    session.delete(asset)
+    session.commit()
+    print("Asset deleted")
+
+
+def export_assets(session: Session) -> None:
+    fmt = input("Format (excel/word/pdf): ").lower()
+    assets = session.query(Asset).all()
+    data = [
+        {
+            "ลำดับ": a.id,
+            "รหัสครุภัณฑ์": a.asset_code,
+            "รหัสย่อย": a.sub_code,
+            "ปีงบประมาณที่ได้มา": a.budget_year,
+            "ชื่อครุภัณฑ์": a.name,
+            "รายละเอียด": a.details,
+            "หมายเลขเครื่อง/SN": a.serial_number,
+            "ประเภท": a.category,
+            "จำนวน": a.quantity,
+            "วันที่ได้มา": a.acquisition_date.strftime("%Y-%m-%d") if a.acquisition_date else "",
+            "หน่วยเบิก": a.unit,
+            "ราคา": a.price,
+            "หมายเหตุ": a.note,
+        }
+        for a in assets
+    ]
+    if fmt == "excel":
+        df = pd.DataFrame(data)
+        df.to_excel("assets.xlsx", index=False)
+        print("Exported to assets.xlsx")
+    elif fmt == "word":
+        doc = Document()
+        table = doc.add_table(rows=1, cols=len(data[0]) if data else 1)
+        hdr_cells = table.rows[0].cells
+        for i, key in enumerate(data[0].keys() if data else ["รายการ"]):
+            hdr_cells[i].text = key
+        for item in data:
+            row_cells = table.add_row().cells
+            for i, key in enumerate(item.keys()):
+                row_cells[i].text = str(item[key])
+        doc.save("assets.docx")
+        print("Exported to assets.docx")
+    elif fmt == "pdf":
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=10)
+        for item in data:
+            line = " | ".join([f"{k}: {v}" for k, v in item.items()])
+            pdf.multi_cell(0, 5, line)
+            pdf.ln(1)
+        pdf.output("assets.pdf")
+        print("Exported to assets.pdf")
+    else:
+        print("Unknown format")
 
 
 def main() -> None:
@@ -55,13 +152,19 @@ def main() -> None:
         if not login(session):
             return
         while True:
-            print("\n1. List assets\n2. Add asset\n3. Quit")
+            print(
+                "\n1. List assets\n2. Add asset\n3. Delete asset\n4. Export assets\n5. Quit"
+            )
             choice = input("Select: ")
             if choice == "1":
                 list_assets(session)
             elif choice == "2":
                 add_asset(session)
             elif choice == "3":
+                delete_asset(session)
+            elif choice == "4":
+                export_assets(session)
+            elif choice == "5":
                 break
 
 


### PR DESCRIPTION
## Summary
- Support full asset details in CLI, including sub-code, budget year, serial number, and more
- Allow removing assets and exporting all records to Excel, Word, or PDF from the command line

## Testing
- `python inventory_cli.py --initdb`
- `python - <<'PY'
from sqlalchemy import create_engine
from sqlalchemy.orm import sessionmaker
from models import init_db, Asset
from inventory_cli import list_assets, export_assets, delete_asset
from unittest.mock import patch
engine = create_engine('sqlite:///inventory.db')
init_db(engine)
SessionLocal = sessionmaker(bind=engine)
with SessionLocal() as session:
    if not session.query(Asset).first():
        session.add(Asset(asset_code='T1', name='Test', quantity=2))
        session.commit()
    print('Listing:')
    list_assets(session)
    print('Exporting:')
    with patch('builtins.input', lambda _: 'excel'):
        export_assets(session)
    print('Deleting:')
    asset_id = session.query(Asset).first().id
    with patch('builtins.input', lambda _: str(asset_id)):
        delete_asset(session)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aeb233a1b08322adc07a948a0b7aa9